### PR TITLE
Update python_version for 3.13

### DIFF
--- a/mfeepo.json
+++ b/mfeepo.json
@@ -17,7 +17,7 @@
     "latest_tested_versions": [
         "McAfee ePO v5.3.2"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "license": "Copyright (c) 2016-2025 Splunk Inc.",
     "fips_compliant": true,
     "configuration": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)