### PR TITLE
Fix python_version format

### DIFF
--- a/mfeepo.json
+++ b/mfeepo.json
@@ -17,10 +17,7 @@
     "latest_tested_versions": [
         "McAfee ePO v5.3.2"
     ],
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "license": "Copyright (c) 2016-2025 Splunk Inc.",
     "fips_compliant": true,
     "configuration": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)